### PR TITLE
Fixed exit code from the script

### DIFF
--- a/4-storage/storage-loader/bin/snowplow-storage-loader
+++ b/4-storage/storage-loader/bin/snowplow-storage-loader
@@ -71,7 +71,7 @@ rescue loader::Error => e
   $stderr.puts(e.message)
   exit 1
 rescue SystemExit => e
-  exit 1
+  exit e.status
 rescue Exception => e
   $stderr.puts("Unexpected error: " + e.message)
   $stderr.puts(e.backtrace.join("\n"))


### PR DESCRIPTION
If the script exits with exit code "0", the exception trap changes that to 1 which is not correct. Similar to the emr-etl-runner, it should be changed so that the original exit code is returned.